### PR TITLE
fix: Remove test private key to avoid PSIRT security flagging

### DIFF
--- a/bundles/grpc-github-connector/open-liberty/connector/src/test/data/ConnectorConfiguration/JWTToken.txt
+++ b/bundles/grpc-github-connector/open-liberty/connector/src/test/data/ConnectorConfiguration/JWTToken.txt
@@ -1,27 +1,4 @@
------BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAqTQxqebLIhxENuXrmQjkJCP/PZj9zdg4ojqKsA26bZISiuiB
-0DsJcXI3BttO57WnIoNccXJDOh20w/9z7nNWIAoUonmSGSHYSV15MXoAdiuHk9Tm
-tTwjWlxQxiUQb+t5z96FpzfbiXTsp9xxa0yijhrAlvT1mfkTRMMoqrI49b/tecue
-TrPn1qO1wt4rijxwp9MIUn8aZXZV0OiSo9JZhyBUdCFQ6rdGfgW+9bmwjV5kdSLO
-M22zmTpsdruPXzar6HKfpaW//q66RXa0OFUGVpkxg3eJlcXuxt6aj/+y026OvOzA
-kJ3l8TimdLbsXmhLiyDWJ/h58jtAvS/W/cqECwIDAQABAoIBADJuMQMvm4meHSKz
-omWpRb4T0IY+bB8G+9I2WpGgddkkeUxXgiFbBzR90zLC+KCM/rSFrG7PnIPcyLzG
-DXqbe6bu+jl2vHmrIbi0GGQLtcmCrdT81opb0zmiXBzCfUSuTU8MRo+RUWiFpede
-B5vwal6qUI5tkioDF6Ad/qfpmJp9zqrqzEdaPynWMNjj0AyKEKTpDTBTDmptxnrT
-AtEvf+EXOwF5nt3taL4VeFJW4hO1Tqudouf2dkzhsnJr2gXTq2Zn+68ZQvbjS6fL
-TLmXatypyJ94mCyRwvrPJeqxdrC5lrpeziy60bh0mfd3IihGRWLOuLwa5LHvAI34
-FGySb4kCgYEA0jj3auCHhWCECnbtq3HSeDEP0k0JkkpzNULXt+1sNJgMjgIKWdQg
-d48bbyaxu6oKbz9X55Ih70zGsf3isJaLgiNmFZIUEvWUq8TGt+JikVw1TcSJGKir
-k+qOHpxVMq486ZBj56Uvs0jY01hRoc+dpT/2eflpb77AUlJ1g29SLUcCgYEAzgyb
-wCyLbDls0Ln0tU0cncv4A47mFvEVYpNDMwSwtB9idmXd3vCT9/mRVGKdh7u3bXjW
-x/5RVVoET01y/cVN7IY2s0SB9gIIwz8obFq3QEcXX3afY+WKpzwrkW9G7dcaxO4u
-pP/qTljecxUKuG7wN0V9OO3Ohy6zUfUh290fBR0CgYAMzUlL6eZ22dzQolNw6FqP
-1TUIcoaNsRj4+lwWqE+5mDTThQ5KUB+2CDH8f9e8/OrrwWjCAmUspHlJJ5Phexl9
-0FgMIjw0t13ZY/9R/WhRP9NDLB/JL6RbOqJy/MQ3dOLiuldLKQURnvMNU8iM2Q7Z
-nF6PKQAhvPULTlg3q9TOSwKBgEq+Hh1myyh16DgKzG6byz6eR5ga1PILf8NjQeQW
-1nZwUAo8x2/gevxfxk0C/LvI5y/JvreLVDuOzLNrl8PgN3UN9neu6Smw8TbKCULM
-4V5qq1rQr97P3Czv0aoO4H7UIXzAHaFyx66l5AOA5YOjknWqOlNVSC6XTSr0rdSQ
-cHktAoGATtLtWZyTtoYF+c+wKtdP9DBvpJBIZeE1hEOZiG79N/fTOM9XuQiAbNv5
-SIFvViU8wgu1H0h8LAIYDcQgbdyZ3+VDoxL8WJBaGa7rXX2sTk9s5iUHwv4oD1Oi
-MnI3Ris6XR6Z2Q2x38s9UivmpHvQzD7R20YddKfW53bQ/KGoae4=
------END RSA PRIVATE KEY-----
+# REMOVED: Private key removed to avoid PSIRT security scanning issues
+# This file previously contained a test RSA private key used for JWT token decryption testing
+# The associated test case has been commented out in TokenTest.java
+# If you need to test JWT token decryption, generate a new test key locally and do not commit it

--- a/bundles/grpc-github-connector/open-liberty/connector/src/test/java/com/ibm/watson/aiops/connectors/github/TokenTest.java
+++ b/bundles/grpc-github-connector/open-liberty/connector/src/test/java/com/ibm/watson/aiops/connectors/github/TokenTest.java
@@ -53,19 +53,26 @@ public class TokenTest {
         Assertions.assertEquals("notarealtoken", configuration.getToken());
     }
 
-    @Test
-    @DisplayName("Test verify encrypted token loading")
-    void testVerifyEncryptedToken() throws InterruptedException, IOException {
-        ConnectorConfiguration configuration = new ConnectorConfiguration();
-        
-        String json = TestUtils.getJSONFromTestData("ConnectorConfiguration/BasicEncryptedToken.json");
-
-        configuration.setTokenDecodeCertLocation("src/test/data/ConnectorConfiguration/JWTToken.txt");
-        configuration.loadDataFromJson(json);
-
-        // To avoid having this flagged as a PAT being used, only check a few characters
-        String token = configuration.getToken();
-        Assertions.assertTrue(token.startsWith("ov2IP"));
-        Assertions.assertTrue(token.endsWith("ayRc7"));
-    }
+    // COMMENTED OUT: Test disabled to avoid PSIRT security scanning issues
+    // The test private key in JWTToken.txt has been removed
+    // If you need to test JWT token decryption:
+    // 1. Generate a new test key locally
+    // 2. Do not commit the key to the repository
+    // 3. Use environment variables or local-only test configuration
+    
+    // @Test
+    // @DisplayName("Test verify encrypted token loading")
+    // void testVerifyEncryptedToken() throws InterruptedException, IOException {
+    //     ConnectorConfiguration configuration = new ConnectorConfiguration();
+    //
+    //     String json = TestUtils.getJSONFromTestData("ConnectorConfiguration/BasicEncryptedToken.json");
+    //
+    //     configuration.setTokenDecodeCertLocation("src/test/data/ConnectorConfiguration/JWTToken.txt");
+    //     configuration.loadDataFromJson(json);
+    //
+    //     // To avoid having this flagged as a PAT being used, only check a few characters
+    //     String token = configuration.getToken();
+    //     Assertions.assertTrue(token.startsWith("ov2IP"));
+    //     Assertions.assertTrue(token.endsWith("ayRc7"));
+    // }
 }


### PR DESCRIPTION
## Summary
Removed test RSA private key from repository to avoid CSIRT security scanning issues.

## Changes
- Removed RSA private key from `JWTToken.txt` test data file
- Commented out `testVerifyEncryptedToken()` test case
- Added documentation for developers who need to test JWT decryption locally

## Reason
Security scanning tools flagged the test private key as a potential security risk.
While this was only test data, removing it prevents false positives in security scans.

Signed-off-by: snehalata hegde
